### PR TITLE
User notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,12 +2,12 @@ class NotificationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @notifications = current_user.notifications.order(created_at: :desc)
-  end
+    # Fetch notifications data here
+    notifications_data = {
+      unread_count: current_user.notifications.unread.count
+      # Other relevant data you may need
+    }
 
-  def mark_as_read
-    notification = current_user.notifications.find(params[:id])
-    notification.update(read: true)
-    render json: { success: true }
+    render json: notifications_data
   end
 end

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -1,16 +1,11 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
-// Connects to data-controller="notification"
 export default class extends Controller {
-  static targets = ["count"];
+  static targets = ["badge"];
 
   connect() {
-    // This timeout removes the notification after 5 seconds
-    const notificationElement = this.element;
-    setTimeout(() => {
-      notificationElement.remove();
-    }, 3000);
-
+    // Initially hide the badge
+    this.toggleBadgeVisibility();
     this.loadNotifications();
   }
 
@@ -18,8 +13,22 @@ export default class extends Controller {
     fetch("/notifications")
       .then(response => response.json())
       .then(data => {
-        this.countTarget.innerText = data.unread_count;
+        this.count = data.unread_count;
+        this.updateBadge();
+        this.toggleBadgeVisibility();
       });
+  }
+
+  toggleBadgeVisibility() {
+    if (this.count > 0) {
+      this.badgeTarget.classList.remove("d-none");
+    } else {
+      this.badgeTarget.classList.add("d-none");
+    }
+  }
+
+  updateBadge() {
+    this.badgeTarget.innerText = this.count;
   }
 
   markAsRead(event) {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -34,8 +34,8 @@
                 <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <%= image_tag current_user.avatar, class: "avatar-large border border-2 border-dark", alt: "dropdown menu" %>
                 </a>
-                <span class="badge badge-danger" data-notifications-target="count">
-                  <%= current_user.notifications.unread.count %>
+                <span class="badge badge-danger d-none" data-controller="notification" data-notification-target="badge">
+                  <!-- Badge content will be updated dynamically by Stimulus -->
                 </span>
               <% else %>
                 <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     member do
       get 'profile', to: 'users#show'
       get 'account_overview', to: 'users#account_overview'
-      # favorite feature 
+      # favorite feature
       post 'toggle_favorite', to: "users#toggle_favorite"
     end
     resources :bookings, only: [:create, :destroy]
@@ -27,10 +27,6 @@ Rails.application.routes.draw do
     resources :feedbacks, only: [:new, :create]
   end
 
-  # Add routes for notifications
-  resources :notifications, only: [:index] do
-    member do
-      patch :mark_as_read
-    end
-  end
+  # Other routes...
+  resources :notifications, only: [:index]
 end

--- a/db/migrate/20240701114143_drop_noticed_notifications_table.rb
+++ b/db/migrate/20240701114143_drop_noticed_notifications_table.rb
@@ -1,0 +1,20 @@
+class DropNoticedNotificationsTable < ActiveRecord::Migration[7.1]
+  def up
+    drop_table :noticed_notifications
+  end
+
+  def down
+    create_table :noticed_notifications do |t|
+      t.string :type
+      t.bigint :event_id, null: false
+      t.string :recipient_type, null: false
+      t.bigint :recipient_id, null: false
+      t.datetime :read_at
+      t.datetime :seen_at
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [:event_id], name: "index_noticed_notifications_on_event_id"
+      t.index [:recipient_type, :recipient_id], name: "index_noticed_notifications_on_recipient"
+    end
+  end
+end

--- a/db/migrate/20240701114324_drop_noticed_events_table.rb
+++ b/db/migrate/20240701114324_drop_noticed_events_table.rb
@@ -1,0 +1,18 @@
+class DropNoticedEventsTable < ActiveRecord::Migration[7.1]
+  def up
+    drop_table :noticed_events
+  end
+
+  def down
+    create_table :noticed_events do |t|
+      t.string :type
+      t.string :record_type
+      t.bigint :record_id
+      t.jsonb :params
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.integer :notifications_count
+      t.index [:record_type, :record_id], name: "index_noticed_events_on_record"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_01_114143) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_01_114324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,17 +71,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_01_114143) do
     t.index ["favoritor_id", "favoritor_type"], name: "fk_favorites"
     t.index ["favoritor_type", "favoritor_id"], name: "index_favorites_on_favoritor"
     t.index ["scope"], name: "index_favorites_on_scope"
-  end
-
-  create_table "noticed_events", force: :cascade do |t|
-    t.string "type"
-    t.string "record_type"
-    t.bigint "record_id"
-    t.jsonb "params"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "notifications_count"
-    t.index ["record_type", "record_id"], name: "index_noticed_events_on_record"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_28_120123) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_01_114143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,19 +82,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_120123) do
     t.datetime "updated_at", null: false
     t.integer "notifications_count"
     t.index ["record_type", "record_id"], name: "index_noticed_events_on_record"
-  end
-
-  create_table "noticed_notifications", force: :cascade do |t|
-    t.string "type"
-    t.bigint "event_id", null: false
-    t.string "recipient_type", null: false
-    t.bigint "recipient_id", null: false
-    t.datetime "read_at", precision: nil
-    t.datetime "seen_at", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["event_id"], name: "index_noticed_notifications_on_event_id"
-    t.index ["recipient_type", "recipient_id"], name: "index_noticed_notifications_on_recipient"
   end
 
   create_table "notifications", force: :cascade do |t|


### PR DESCRIPTION
Removed two tables I had added to our schema because I intended to use a gem for the Notifications, which ultimately seemed too difficult. New migration files created and two tables removed from schema.